### PR TITLE
Added support for srem

### DIFF
--- a/cmd/sets/sets.go
+++ b/cmd/sets/sets.go
@@ -13,6 +13,7 @@ func init() {
 	cmd.Register("sdiffstore", sdiffstore)
 	cmd.Register("sismember", sismember)
 	cmd.Register("smembers", smembers)
+	cmd.Register("srem", srem)
 }
 
 var sadd = cmd.NewSingleKeyCmd(
@@ -178,6 +179,25 @@ func smembersFn(k srv.Key, args []string, ints []int64, floats []float64) (inter
 	v := k.Val()
 	if v, ok := v.(types.Set); ok {
 		return v.SMembers(), nil
+	}
+	return nil, cmd.ErrInvalidValType
+}
+
+var srem = cmd.NewSingleKeyCmd(
+	&cmd.ArgDef{
+		MinArgs: 1,
+		MaxArgs: -1,
+	},
+	srv.NoKeyDefaultVal,
+	sremFn)
+
+func sremFn(k srv.Key, args []string, ints []int64, floats []float64) (interface{}, error) {
+	k.RLock()
+	defer k.RUnlock()
+
+	v := k.Val()
+	if v, ok := v.(types.Set); ok {
+		return v.SRem(args[1:]...), nil
 	}
 	return nil, cmd.ErrInvalidValType
 }

--- a/cmd/test/commands_test.go
+++ b/cmd/test/commands_test.go
@@ -286,6 +286,8 @@ func TestCommand(t *testing.T) {
 		{"sdiff", []string{"k", "k"}, []string{}, nil},
 		{"sdiff", []string{"s", "k2", "k3"}, nil, cmd.ErrInvalidValType},
 		{"sdiff", []string{"k", "l", "k3"}, nil, cmd.ErrInvalidValType},
+		{"srem", []string{"k","a","b"},int64(2),nil},
+		{"srem", []string{"k","j"},int64(0),nil},
 		{"sdiffstore", []string{"j", "k", "k2", "k3"}, int64(2), nil},
 		{"sdiffstore", []string{"k3", "k", "k2", "k3"}, int64(2), nil}, // TODO : Triggers deadlock
 	}


### PR DESCRIPTION
Hi,

This adds some basic support for srem. It passes through your current testing infrastructure. Fair warning unless you remove the sdiffstore in commands_test.go it will just get passed without actually completing due to the deadlock.
